### PR TITLE
Update __init__.py

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -115,7 +115,7 @@ class ToastNotifier(object):
         return None
 
     def show_toast(self, title="Notification", msg="Here comes the message",
-                    icon_path=None, duration=5, threaded=False):
+                    icon_path=None, duration=5, threaded=True):
         """Notification settings.
 
         :title: notification title


### PR DESCRIPTION
changed so that the notifications are always threaded . Seeing they are low processing power with it enabled ... and it prevents difficult-to-solve errors when running multiple files using desktop-notifications simultaneously . Solving the the issue here
https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/18

simple change